### PR TITLE
Add laravel 5.5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   ],
   "require": {
     "php": ">=5.5.9",
-    "laravel/framework": "5.1.*|5.2.*|5.3.*|5.4.*"
+    "laravel/framework": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*"
   },
   "autoload": {
     "psr-4": {

--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -25,11 +25,22 @@ class PublishCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->info('Publishing all files');
         $this->call('vendor:publish', [
             '--provider' => 'Graphiql\GraphiqlServiceProvider',
         ]);
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @deprecated
+     * @return void
+     */
+    public function fire()
+    {
+        $this->handle();
     }
 }


### PR DESCRIPTION
This PR adds `5.5.*` in the composer.json and changes Command.php

In Laravel 5.5 `fire` is not available anymore in Commands, `handle` has to be used. To retain backwards compatibility with Laravel < 5.4 I kept an implementation of `fire`

See https://github.com/laravel/framework/pull/20024